### PR TITLE
Preferred text.pug file over html2text

### DIFF
--- a/README.md
+++ b/README.md
@@ -467,6 +467,8 @@ email
 
 If you'd like to customize the text body, you can pass `message.text` or create a `text` template file just like you normally would for `html` and `subject`.
 
+You may also set `config.htmlToText: false` to force the usage of the `text` template file.
+
 ```js
 const Email = require('email-templates');
 

--- a/README.md
+++ b/README.md
@@ -465,7 +465,7 @@ email
 
 > By default we use `html-to-text` to generate a plaintext version and attach it as `message.text`.
 
-If you'd like to customize the text body, you can pass `message.text` or set `config.htmlToText: false` (doing so will automatically lookup a `text` template file just like it normally would for `html` and `subject`).
+If you'd like to customize the text body, you can pass `message.text` or create a `text` template file just like you normally would for `html` and `subject`.
 
 ```js
 const Email = require('email-templates');
@@ -671,7 +671,7 @@ Instead of having to configure this for yourself, you could just use [Lad][] ins
 [MIT](LICENSE) © [Nick Baugh](http://niftylettuce.com)
 
 
-## 
+##
 
 [node]: https://nodejs.org
 

--- a/src/index.js
+++ b/src/index.js
@@ -210,16 +210,13 @@ class Email {
         if (!message.html && htmlTemplateExists)
           message.html = await this.render(`${template}/html`, locals);
 
-        if (
-          (!htmlTemplateExists || !this.config.htmlToText) &&
-          !message.text &&
-          textTemplateExists
-        )
+        if (!message.text && textTemplateExists)
           message.text = await this.render(
             `${template}/text`,
             Object.assign({}, locals, { pretty: false })
           );
-        else if (this.config.htmlToText && message.html)
+
+        if (this.config.htmlToText && message.html && !message.text)
           // we'd use nodemailer-html-to-text plugin
           // but we really don't need to support cid
           // <https://github.com/andris9/nodemailer-html-to-text>

--- a/test/fixtures/emails/test-html-only/html.pug
+++ b/test/fixtures/emails/test-html-only/html.pug
@@ -1,0 +1,13 @@
+doctype html
+html
+  head
+    block head
+      meta(charset="utf-8")
+      meta(name="viewport", content="width=device-width")
+      meta(http-equiv="X-UA-Compatible", content="IE=edge")
+      meta(name="x-apple-disable-message-reformatting")
+      title= subject
+      link(rel="stylesheet", href="style.css", data-inline)
+  body
+    p Hi #{name},
+    p This is just a html test.

--- a/test/fixtures/emails/test-html-only/subject.pug
+++ b/test/fixtures/emails/test-html-only/subject.pug
@@ -1,0 +1,1 @@
+=`Test email for ${name}`

--- a/test/fixtures/emails/test/html.pug
+++ b/test/fixtures/emails/test/html.pug
@@ -10,4 +10,4 @@ html
       link(rel="stylesheet", href="style.css", data-inline)
   body
     p Hi #{name},
-    p This is just a test.
+    p This is just a html test.

--- a/test/fixtures/emails/test/text.pug
+++ b/test/fixtures/emails/test/text.pug
@@ -1,2 +1,2 @@
 | Hi #{name},
-| This is just a test.
+| This is just a text test.

--- a/test/test.js
+++ b/test/test.js
@@ -94,6 +94,11 @@ test('send email', async t => {
     locals: { name: 'niftylettuce' }
   });
   t.true(_.isObject(res));
+  const message = JSON.parse(res.message);
+  t.true(_.has(message, 'html'));
+  t.regex(message.html, /This is just a html test/);
+  t.true(_.has(message, 'text'));
+  t.regex(message.text, /This is just a text test/);
 });
 
 test('send two emails with two different locals', async t => {
@@ -266,6 +271,11 @@ test('send email with html to text disabled', async t => {
     locals: { name: 'niftylettuce' }
   });
   t.true(_.isObject(res));
+  const message = JSON.parse(res.message);
+  t.true(_.has(message, 'html'));
+  t.regex(message.html, /This is just a html test/);
+  t.true(_.has(message, 'text'));
+  t.regex(message.text, /This is just a text test/);
 });
 
 test('inline css with juice using render', async t => {
@@ -379,5 +389,5 @@ test('render text-only email with `textOnly` option', async t => {
   t.true(_.isObject(res));
   res.message = JSON.parse(res.message);
   t.true(_.isUndefined(res.message.html));
-  t.is(res.message.text, 'Hi niftylettuce,\nThis is just a test.');
+  t.is(res.message.text, 'Hi niftylettuce,\nThis is just a text test.');
 });

--- a/test/test.js
+++ b/test/test.js
@@ -278,6 +278,38 @@ test('send email with html to text disabled', async t => {
   t.regex(message.text, /This is just a text test/);
 });
 
+test('send email with missing text template', async t => {
+  const email = new Email({
+    views: { root },
+    message: {
+      from: 'niftylettuce+from@gmail.com'
+    },
+    transport: {
+      jsonTransport: true
+    },
+    juiceResources: {
+      webResources: {
+        relativeTo: root
+      }
+    }
+  });
+  const res = await email.send({
+    template: 'test-html-only',
+    message: {
+      to: 'niftylettuce+to@gmail.com',
+      cc: 'niftylettuce+cc@gmail.com',
+      bcc: 'niftylettuce+bcc@gmail.com'
+    },
+    locals: { name: 'niftylettuce' }
+  });
+  t.true(_.isObject(res));
+  const message = JSON.parse(res.message);
+  t.true(_.has(message, 'html'));
+  t.regex(message.html, /This is just a html test/);
+  t.true(_.has(message, 'text'));
+  t.regex(message.text, /This is just a html test/);
+});
+
 test('inline css with juice using render', async t => {
   const email = new Email({
     views: { root },

--- a/yarn.lock
+++ b/yarn.lock
@@ -4810,7 +4810,7 @@ remark-heading-gap@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/remark-heading-gap/-/remark-heading-gap-3.0.0.tgz#f52ac47a27995ef3248a59eb7544b5620b4736a6"
 
-"remark-license@github:niftylettuce/remark-license":
+remark-license@niftylettuce/remark-license:
   version "4.0.1"
   resolved "https://codeload.github.com/niftylettuce/remark-license/tar.gz/17ecb8f64f8f6082414d14f9267a12764e6ddbfb"
   dependencies:


### PR DESCRIPTION
I have a use case where I need html2text to run when a text template file is missing, but I need the text template to be used if it does exist.

With this change, I have preferred the text template file over the result of html2text. I have also added a bit more coverage on the contents of the message returned from the send method.