### PR TITLE
Map .hbs template files to .handlebars by default

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -35,7 +35,9 @@ class Email {
           options: {
             // default file extension for template
             extension: 'pug',
-            map: {},
+            map: {
+              hbs: 'handlebars'
+            },
             engineSource: consolidate
           },
           // locals to pass to templates for rendering


### PR DESCRIPTION
Based on the solution proposed by @BrianDV for #276 