### PR TITLE
Custom render function shouldn't look for templates on disk

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -28,6 +28,9 @@ class Email {
       config.juice = false;
       delete config.disableJuice;
     }
+    if (config.render) {
+      config.customRender = true;
+    }
 
     this.config = _.merge(
       {
@@ -58,6 +61,7 @@ class Email {
         i18n: false,
         // pass a custom render function if necessary
         render: this.render.bind(this),
+        customRender: false,
         // force text-only rendering of template (disregards template folder)
         textOnly: false,
         // <https://github.com/werk85/node-html-to-text>
@@ -188,9 +192,9 @@ class Email {
   renderAll(template, locals = {}, message = {}) {
     return new Promise(async (resolve, reject) => {
       try {
-        let subjectTemplateExists = false;
-        let htmlTemplateExists = false;
-        let textTemplateExists = false;
+        let subjectTemplateExists = this.config.customRender;
+        let htmlTemplateExists = this.config.customRender;
+        let textTemplateExists = this.config.customRender;
 
         const promises = [
           this.templateExists(`${template}/subject`),
@@ -198,7 +202,7 @@ class Email {
           this.templateExists(`${template}/text`)
         ];
 
-        if (template)
+        if (template && !this.config.customRender)
           [
             subjectTemplateExists,
             htmlTemplateExists,

--- a/test/test.js
+++ b/test/test.js
@@ -275,6 +275,46 @@ test('throws error with missing template on render call', async t => {
   t.regex(error.message, /no such file or directory/);
 });
 
+test('send mail with custom render function and no templates', async t => {
+  const email = new Email({
+    render: view => {
+      return new Promise(async resolve => {
+        let res;
+        if (view === 'noFolder/subject') {
+          res = 'Test subject';
+        } else if (view === 'noFolder/html') {
+          res = 'Test html';
+        } else {
+          res = '';
+        }
+        resolve(await email.juiceResources(res));
+      });
+    },
+    transport: {
+      jsonTransport: true
+    },
+    juiceResources: {
+      webResources: {
+        relativeTo: root
+      }
+    }
+  });
+  const res = await email.send({
+    template: 'noFolder',
+    message: {
+      to: 'niftylettuce+to@gmail.com'
+    },
+    locals: {
+      name: 'niftylettuce',
+      locale: 'en'
+    }
+  });
+  const msg = JSON.parse(res.message);
+  t.true(_.isObject(res));
+  t.is(msg.subject, 'Test subject');
+  t.is(msg.html, 'Test html');
+});
+
 test('send email with html to text disabled', async t => {
   const email = new Email({
     views: { root },


### PR DESCRIPTION
If a custom render function is passed in the config, `renderAll` was looking for templates on disk anyway, and if those were non-existent, it would fail to

This change avoids that lookup, and renders whatever the custom render function returns.

Closes issue #288.