### PR TITLE
Allow absolute template paths

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -106,13 +106,16 @@ class Email {
   }
 
   // a simple helper function that gets the actual file path for the template
-  async getTemplatePath(view) {
+  async getTemplatePath(template) {
+    const [root, view] = path.isAbsolute(template)
+      ? [path.dirname(template), path.basename(template)]
+      : [this.config.views.root, template];
     const paths = await getPaths(
-      this.config.views.root,
+      root,
       view,
       this.config.views.options.extension
     );
-    const filePath = path.resolve(this.config.views.root, paths.rel);
+    const filePath = path.resolve(root, paths.rel);
     return { filePath, paths };
   }
 

--- a/test/test.js
+++ b/test/test.js
@@ -101,6 +101,48 @@ test('send email', async t => {
   t.regex(message.text, /This is just a text test/);
 });
 
+test('throws with non-existing absolute template path', async t => {
+  const email = new Email({
+    transport: {
+      jsonTransport: true
+    },
+    juiceResources: {
+      webResources: {
+        relativeTo: root
+      }
+    }
+  });
+  const nonExistingAbsolutePath = path.join(
+    __dirname,
+    'fixtures',
+    'emails',
+    'tests'
+  );
+  const error = await t.throws(email.render(nonExistingAbsolutePath));
+  t.regex(error.message, /no such file or directory/);
+});
+
+test('sends with absolute template path', async t => {
+  const email = new Email({
+    transport: {
+      jsonTransport: true
+    },
+    juiceResources: {
+      webResources: {
+        relativeTo: root
+      }
+    }
+  });
+  const absolutePath = path.join(__dirname, 'fixtures', 'emails', 'test');
+  const res = await email.send({ template: absolutePath });
+  t.true(_.isObject(res));
+  const message = JSON.parse(res.message);
+  t.true(_.has(message, 'html'));
+  t.regex(message.html, /This is just a html test/);
+  t.true(_.has(message, 'text'));
+  t.regex(message.text, /This is just a text test/);
+});
+
 test('send email with subject prefix', async t => {
   const email = new Email({
     views: { root },


### PR DESCRIPTION
One can now specify an absolute path for templates and views root is ignored in that case.

Fixes 
https://github.com/niftylettuce/email-templates/issues/320
https://github.com/niftylettuce/bug-bounties/issues/1
